### PR TITLE
Improve flattening with * wildcard

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==19.2.3
+-e .
 bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
@@ -9,5 +9,8 @@ Sphinx==3.0.4
 twine==1.14.0
 
 mypy
-pytest==4.6.5
-pytest-runner==5.1
+pytest
+esbonio
+pylint
+doc8
+black

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,3 @@ exclude = docs
 # Define setup.py command aliases here
 test = pytest
 
-[tool:pytest]
-collect_ignore = ['setup.py']
-


### PR DESCRIPTION
Removed all skips in tests as all functionalities should now be working.

I also rewrote dget to not use recursion as it was easier to make it
work this way and I think it should be more efficient for very big
structures (though probably not a use case).