### PR TITLE
Improve package versioning to resolve #7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 0.1.4
+commit = True
+
+[bumpversion:file:deeppath/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    # Here we don't use ${GITHUB_REF_NAME#v} since it won't parse in the name field.
+    - name: Bump package version to ${{ github.ref_name }}
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+        pip install bump2version==1.0.1
+        # Here we don't use ${{ github.ref_name }} since github action variables can't do sed/cut/slicing
+        # Remove leading 'v' from the tag name
+        bump2version --new-version ${GITHUB_REF_NAME#v} minor
+        # must supply either patch minor or major see https://github.com/c4urself/bump2version/issues/244
+        # but it's an ignored argument argument
+        git show
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ github.ref_name }}
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -34,6 +37,7 @@ jobs:
         # must supply either patch minor or major see https://github.com/c4urself/bump2version/issues/244
         # but it's an ignored argument argument
         git show
+        git push
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/deeppath/__init__.py
+++ b/deeppath/__init__.py
@@ -1,7 +1,7 @@
-"""Top-level package for deeppath."""
+"""Easily access nested structures with using an xpath like syntax."""
 
-__author__ = """Loic Leyendecker"""
+__author__ = "Loic Leyendecker"
 __email__ = "loic.leyendecker@gmail.com"
-__version__ = "0.1.1"
+__version__ = "0.1.4"
 
 from deeppath.deeppath import dget, dset, dwalk, flatten

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:deeppath/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -23,4 +10,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
-
 """The setup script."""
 
 from setuptools import find_packages, setup
+from deeppath import __version__
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
@@ -44,6 +43,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/loicleyendecker/deeppath",
-    version="0.1.4",
+    version=__version__,
     zip_safe=False,
 )


### PR DESCRIPTION
- Add automatic version bumping when a new release is created via
https://github.com/loicleyendecker/deeppath/releases/new
- tag name must be semver and follow va.b.c
- move bump2version config from setup.cfg to .bumpversion.cfg
since it will delete any comments in the cfg files
see https://github.com/c4urself/bump2version/issues/37