### PR TITLE
Allow any key not only alphas (#14)

### DIFF
--- a/deeppath/deeppath.py
+++ b/deeppath/deeppath.py
@@ -1,22 +1,25 @@
 """Support some XPath-like syntax for accessing nested structures"""
 
 import re
+from logging import getLogger
 from typing import (
+    Any,
+    Dict,
     Generator,
+    Iterable,
     List,
     Mapping,
     MutableMapping,
     MutableSequence,
-    Sequence,
-    Iterable,
-    Any,
-    Union,
     Optional,
+    Sequence,
     Tuple,
-    Dict,
+    Union,
 )
 
-_REPETITION_REGEX = re.compile(r"([\w\*]+)\[([\d-]+)\]")
+_REPETITION_REGEX = re.compile(r"([^\[]+)\[([\d-]+)\]")
+
+_logger = getLogger(__name__)
 
 
 def flatten(nested_iterable: Iterable[Any]) -> List[Any]:
@@ -38,6 +41,7 @@ def _get_repetition_index(key: str) -> Optional[Tuple[str, int]]:
     does not match the expected regex"""
     match = _REPETITION_REGEX.search(key)
     if match:
+        _logger.debug("key=%s, match groups=%s", key, match.groups())
         key = match.group(1)
         repetition_number = match.group(2)
         return key, int(repetition_number)
@@ -89,6 +93,7 @@ def dset(
         path = path[1:]
     for key in path.split("/")[:-1]:
         subpath = _get_repetition_index(key)
+        _logger.debug("path=%s, key=%s, subpath=%s", path, key, subpath)
         if not subpath:
             if key not in data:
                 data[key] = {}
@@ -102,6 +107,7 @@ def dset(
             data = data[key][index]
 
     last = _get_repetition_index(path.split("/")[-1])
+    _logger.debug("path=%s, last=%s", path, last)
     if not last:
         data[path.split("/")[-1]] = value
     else:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ twine==1.14.0
 mypy
 pytest==4.6.5
 pytest-runner==5.1
+pytest-faker==2.0.0

--- a/tests/test_deeppath.py
+++ b/tests/test_deeppath.py
@@ -8,6 +8,7 @@ import pytest
 
 from deeppath import dget, dset, dwalk, flatten
 
+
 @dataclass(frozen=True)
 class Person:
     name: str
@@ -23,6 +24,7 @@ class Person:
         age = int(dget(data, "somewhere/else/age"))
         birthday = datetime.date(*dget(data, "other/location/birthday/*"))
         return cls(name, age, birthday, **kwargs)
+
 
 @dataclass(frozen=True)
 class InterestedPerson(Person):
@@ -132,7 +134,6 @@ def test_dget_flatten_and_repetition():
     assert dget(data2, "*/a") is None
 
 
-
 def test_dget_flatten():
     """Check that we can successfully flatten a nested structure"""
     data = {"deeply": {"nested": [{"path": 2}, {"path": 3}, {"path": 4}]}}
@@ -230,3 +231,23 @@ def test_flatten():
     assert flatten([[{"documentDetails": {"number": "0"}}]]) == [
         {"documentDetails": {"number": "0"}}
     ]
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "some_key",
+        "2@3@4",
+        "2.3.4",
+        "2-3-4",
+        "2-3.4",
+        "2-3 4",
+        "2.3 4",
+        "2 3 4_5",
+    ],
+)
+def test_dset_with_dots(key, faker):
+    d = dict()
+    value = faker.name()
+    dset(d, f"1/{key}[0]", value)
+    assert d == {"1": {key: [value]}}


### PR DESCRIPTION
The only true change is in `_REPETITION_REGEX` and `test_dset_with_dots`.

This is based on my understanding what key can be: so far, a path like "1/2.3.4[0]" would be effectively treated as "1/4[0]"; this PR allows any without left square bracket "[".

Can remove debug lines if not desirable.